### PR TITLE
Throw std::runtime_error

### DIFF
--- a/src/fetch.h
+++ b/src/fetch.h
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <map>
 #include <unistd.h>
+#include <stdexcept>
 
 using namespace std;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,7 +8,7 @@ string exec(string command)
     FILE *pipe = popen(command.c_str(), "r");
     if (!pipe)
     {
-        return "popen failed!";
+        throw runtime_error("popen failed: \"" + command + "\"");
     }
     while (!feof(pipe))
     {


### PR DESCRIPTION
Throws an object std::runtime_error instead of continuing.