### PR TITLE
is_executable instead of is_regular_file

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -280,56 +280,56 @@ vector<string> getGPU()
 string getPackages()
 {
     string pkg = "";
-    if (Path::of("/bin/dpkg"s).is_regular_file())
+    if (Path::of("/bin/dpkg"s).is_executable())
     {
         auto c = Command::exec("dpkg -l"s);
         pkg += to_string(c.getOutputLines()) + RED + " dpkg; " + RESET;
     }
-    if (Path::of("/bin/snap"s).is_regular_file())
+    if (Path::of("/bin/snap"s).is_executable())
     {
         auto c = Command::exec("snap list"s);
         pkg += to_string(c.getOutputLines()) + RED + " snap; " + RESET;
     }
-    if (Path::of("/bin/pacman"s).is_regular_file())
+    if (Path::of("/bin/pacman"s).is_executable())
     {
         auto c = Command::exec("pacman -Q"s);
         pkg += to_string(c.getOutputLines()) + RED + " pacman; " + RESET;
     }
-    if (Path::of("/bin/flatpak"s).is_regular_file())
+    if (Path::of("/bin/flatpak"s).is_executable())
     {
         auto c = Command::exec("flatpak list"s);
         pkg += to_string(c.getOutputLines()) + RED + " flatpak; " + RESET;
     }
-    if (Path::of("/var/lib/rpm"s).is_regular_file())
+    if (Path::of("/var/lib/rpm"s).is_executable())
     {
         auto c = Command::exec("rpm -qa"s);
         pkg += to_string(c.getOutputLines()) + RED + " rpm; " + RESET;
     }
-    if (Path::of("/bin/npm"s).is_regular_file())
+    if (Path::of("/bin/npm"s).is_executable())
     {
         auto c = Command::exec("npm list"s);
         pkg += to_string(c.getOutputLines()) + RED + " npm; " + RESET;
     }
-    if (Path::of("/bin/emerge"s).is_regular_file()) // gentoo
+    if (Path::of("/bin/emerge"s).is_executable()) // gentoo
     {
         pkg += "not supported"s + RED + " portage; " + RESET;
     }
-    if (Path::of("/bin/xbps-install"s).is_regular_file()) // void linux
+    if (Path::of("/bin/xbps-install"s).is_executable()) // void linux
     {
         auto c = Command::exec("flatpak list"s);
         pkg += to_string(c.getOutputLines()) + RED + " xbps; " + RESET;
     }
-    if (Path::of("/bin/dnf"s).is_regular_file()) // fedora
+    if (Path::of("/bin/dnf"s).is_executable()) // fedora
     {
         auto c = Command::exec("dnf list installed"s);
         pkg += to_string(c.getOutputLines()) + RED + " dnf; " + RESET;
     }
-    if (Path::of("/bin/zypper"s).is_regular_file()) // opensuse
+    if (Path::of("/bin/zypper"s).is_executable()) // opensuse
     {
         auto c = Command::exec("zypper se --installed-only"s);
         pkg += to_string(c.getOutputLines()) + RED + " zypper; " + RESET;
     }
-    if (Path::of("/home/linuxbrew/.linuxbrew/bin/brew"s).is_regular_file())
+    if (Path::of("/home/linuxbrew/.linuxbrew/bin/brew"s).is_executable())
     {
         auto c = Command::exec("brew list | { tr '' '\n'; }"s);
         pkg += to_string(c.getOutputLines()) + RED + " brew; " + RESET;

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -151,8 +151,18 @@ class Path
     {
         return filesystem::is_regular_file(status);
     }
+    bool is_executable()
+    {
+        if (status.permissions() == filesystem::perms::unknown)
+            return false;
+        return (status.permissions() & filesystem::perms::others_exec) != filesystem::perms::none;
+    }
     bool is_directory()
     {
         return filesystem::is_directory(status);
+    }
+    string to_s()
+    {
+        return path.string();
     }
 };

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -116,13 +116,29 @@ static void test_Command()
 
 static void test_Path()
 {
-    auto dir = Path::of("/etc"s);
-    expect(false, dir.is_regular_file(), "[ -f dir ]");
-    expect(true, dir.is_directory(), "[ -d dir ]");
+    // directory
+    auto p = Path::of("/bin"s);
+    expect(false, p.is_regular_file(), "test -f "s + p.to_s());
+    expect(true, p.is_directory(), "test -d "s + p.to_s());
+    expect(true, p.is_executable(), "test -x "s + p.to_s());
 
-    auto reg = Path::of("/bin/sh"s);
-    expect(true, reg.is_regular_file(), "[ -f reg ]");
-    expect(false, reg.is_directory(), "[ -d reg ]");
+    // executable regular file
+    p = Path::of("/bin/sh"s);
+    expect(true, p.is_regular_file(), "test -f "s + p.to_s());
+    expect(false, p.is_directory(), "test -d "s + p.to_s());
+    expect(true, p.is_executable(), "test -x "s + p.to_s());
+
+    // non-executable regular file
+    p = Path::of("Makefile"s);
+    expect(true, p.is_regular_file(), "test -f "s + p.to_s());
+    expect(false, p.is_directory(), "test -d "s + p.to_s());
+    expect(false, p.is_executable(), "test -x "s + p.to_s());
+
+    // not existence path
+    p = Path::of("not_existence"s);
+    expect(false, p.is_regular_file(), "test -f "s + p.to_s());
+    expect(false, p.is_executable(), "test -x "s + p.to_s());
+    expect(false, p.is_directory(), "test -d "s + p.to_s());
 }
 
 void test_util()


### PR DESCRIPTION
## Description

Check not only that the regular file exists, but also that it is executable.