### PR TITLE
Unify identifier naming style with camelCase.

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -315,7 +315,7 @@ int getCPUtemp(string path)
  */
 bool CpuTempCheck()
 {
-    if (Path::of("/sys/class/thermal/thermal_zone1"s).is_directory())
+    if (Path::of("/sys/class/thermal/thermal_zone1"s).isDirectory())
     {
         return true;
     }
@@ -353,56 +353,56 @@ string getPackages()
 {
     auto red = Crayon{}.red();
     string pkg = "";
-    if (Path::of("/bin/dpkg"s).is_executable())
+    if (Path::of("/bin/dpkg"s).isExecutable())
     {
         auto c = Command::exec("dpkg -l"s);
         pkg += to_string(c.getOutputLines()) + red.text(" dpkg; ");
     }
-    if (Path::of("/bin/snap"s).is_executable())
+    if (Path::of("/bin/snap"s).isExecutable())
     {
         auto c = Command::exec("snap list"s);
         pkg += to_string(c.getOutputLines()) + red.text(" snap; ");
     }
-    if (Path::of("/bin/pacman"s).is_executable())
+    if (Path::of("/bin/pacman"s).isExecutable())
     {
         auto c = Command::exec("pacman -Q"s);
         pkg += to_string(c.getOutputLines()) + red.text(" pacman; ");
     }
-    if (Path::of("/bin/flatpak"s).is_executable())
+    if (Path::of("/bin/flatpak"s).isExecutable())
     {
         auto c = Command::exec("flatpak list"s);
         pkg += to_string(c.getOutputLines()) + red.text(" flatpak; ");
     }
-    if (Path::of("/var/lib/rpm"s).is_executable())
+    if (Path::of("/var/lib/rpm"s).isExecutable())
     {
         auto c = Command::exec("rpm -qa"s);
         pkg += to_string(c.getOutputLines()) + red.text(" rpm; ");
     }
-    if (Path::of("/bin/npm"s).is_executable())
+    if (Path::of("/bin/npm"s).isExecutable())
     {
         auto c = Command::exec("npm list"s);
         pkg += to_string(c.getOutputLines()) + red.text(" npm; ");
     }
-    if (Path::of("/bin/emerge"s).is_executable()) // gentoo
+    if (Path::of("/bin/emerge"s).isExecutable()) // gentoo
     {
         pkg += "not supported"s + red.text(" portage; ");
     }
-    if (Path::of("/bin/xbps-install"s).is_executable()) // void linux
+    if (Path::of("/bin/xbps-install"s).isExecutable()) // void linux
     {
         auto c = Command::exec("flatpak list"s);
         pkg += to_string(c.getOutputLines()) + red.text(" xbps; ");
     }
-    if (Path::of("/bin/dnf"s).is_executable()) // fedora
+    if (Path::of("/bin/dnf"s).isExecutable()) // fedora
     {
         auto c = Command::exec("dnf list installed"s);
         pkg += to_string(c.getOutputLines()) + red.text(" dnf; ");
     }
-    if (Path::of("/bin/zypper"s).is_executable()) // opensuse
+    if (Path::of("/bin/zypper"s).isExecutable()) // opensuse
     {
         auto c = Command::exec("zypper se --installed-only"s);
         pkg += to_string(c.getOutputLines()) + red.text(" zypper; ");
     }
-    if (Path::of("/home/linuxbrew/.linuxbrew/bin/brew"s).is_executable())
+    if (Path::of("/home/linuxbrew/.linuxbrew/bin/brew"s).isExecutable())
     {
         auto c = Command::exec("brew list | { tr '' '\n'; }"s);
         pkg += to_string(c.getOutputLines()) + red.text(" brew; ");

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -194,7 +194,7 @@ class Path
     /**
      * @returns exists and is a regular file
      */
-    bool is_regular_file()
+    bool isRegularFile()
     {
         return filesystem::is_regular_file(status);
     }
@@ -202,7 +202,7 @@ class Path
     /**
      * @returns exists and is a executable(or searchable)
      */
-    bool is_executable()
+    bool isExecutable()
     {
         if (status.permissions() == filesystem::perms::unknown)
             return false;
@@ -213,7 +213,7 @@ class Path
     /**
      * @returns exists and is a directory
      */
-    bool is_directory()
+    bool isDirectory()
     {
         return filesystem::is_directory(status);
     }
@@ -221,7 +221,7 @@ class Path
     /**
      * @returns readable reprsentation for dev.
      */
-    string to_s()
+    string toString()
     {
         return path.string();
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -20,27 +20,27 @@ static void test_Path()
 {
     // directory
     auto p = Path::of("/etc"s);
-    expect(false, p.is_regular_file(), "test -f "s + p.to_s());
-    expect(true, p.is_directory(), "test -d "s + p.to_s());
-    expect(true, p.is_executable(), "test -x "s + p.to_s());
+    expect(false, p.isRegularFile(), "test -f "s + p.toString());
+    expect(true, p.isDirectory(), "test -d "s + p.toString());
+    expect(true, p.isExecutable(), "test -x "s + p.toString());
 
     // executable regular file
     p = Path::of("/bin/sh"s);
-    expect(true, p.is_regular_file(), "test -f "s + p.to_s());
-    expect(false, p.is_directory(), "test -d "s + p.to_s());
-    expect(true, p.is_executable(), "test -x "s + p.to_s());
+    expect(true, p.isRegularFile(), "test -f "s + p.toString());
+    expect(false, p.isDirectory(), "test -d "s + p.toString());
+    expect(true, p.isExecutable(), "test -x "s + p.toString());
 
     // non-executable regular file
     p = Path::of("Makefile"s);
-    expect(true, p.is_regular_file(), "test -f "s + p.to_s());
-    expect(false, p.is_directory(), "test -d "s + p.to_s());
-    expect(false, p.is_executable(), "test -x "s + p.to_s());
+    expect(true, p.isRegularFile(), "test -f "s + p.toString());
+    expect(false, p.isDirectory(), "test -d "s + p.toString());
+    expect(false, p.isExecutable(), "test -x "s + p.toString());
 
     // not existence path
     p = Path::of("not_existence"s);
-    expect(false, p.is_regular_file(), "test -f "s + p.to_s());
-    expect(false, p.is_executable(), "test -x "s + p.to_s());
-    expect(false, p.is_directory(), "test -d "s + p.to_s());
+    expect(false, p.isRegularFile(), "test -f "s + p.toString());
+    expect(false, p.isExecutable(), "test -x "s + p.toString());
+    expect(false, p.isDirectory(), "test -d "s + p.toString());
 }
 
 static void test_Crayon()


### PR DESCRIPTION
## Description

Unify identifier naming style with camelCase.

* Path::is_executable() -> Path::isExecutable()
* Path::is_directory() -> Path::isDirectory()
* Path::is_regular_file() -> Path::isRegularFile()
* Path::to_s() -> Path::toString()