### PR TITLE
Make expect() display filename and line number.

### DIFF
--- a/src/fetch.h
+++ b/src/fetch.h
@@ -66,23 +66,31 @@ string getColor(string);
 void test_util();
 
 /**
- * tests that want and got are equal.
- * Fails with the supplied failure message then halt.
+ * Tests that want and got are equal.
+ * Fails with the supplied failure message, file and line then halt.
  * @param want
  * @param got
  * @param msg
+ * @param file
+ * @param line
  */
 template <typename T>
-void expect(const T &want, const T &got, const string &msg)
+void expect1(const T &want, const T &got, const string &msg, const char *file,
+             int line)
 {
     if (want == got)
         return;
 
-    cout << "Error: "s << msg << " ("s << want << "), but got ("s << got << ")"s
-         << endl;
+    if (msg.length() != 0)
+        cout << file << ":"s << line << ": Error: "s << msg << " want ("s
+             << want << "), but got ("s << got << ")"s << endl;
+    else
+        cout << file << ":"s << line << ": Error: want ("s << want
+             << "), but got ("s << got << ")"s << endl;
 
     exit(1);
 }
+#define expect(want, got, msg) expect1(want, got, msg, __FILE__, __LINE__)
 
 /**
  * Command executes a command in a subshell(shell runs on a forked process).


### PR DESCRIPTION
## Description

Make expect() display filename and line number like below.
```
util.cpp:24: Error: test -d /etc (0), but got (1)
```
