### PR TITLE
✨ feat(battery): print battery percentage bar

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -435,6 +435,76 @@ string getPackages()
 }
 
 /**
+ * @brief Utility to check if battery is charging or not
+ * @returns status of battery
+ */
+bool isCharging(string path)
+{
+    fstream fptr;
+    fptr.open(path, ios::in);
+    string status;
+    getline(fptr, status);
+
+    if (status == "Charging")
+    {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * @brief Utility to print battery perecentage bar
+ */
+void print_bar(int battery)
+{
+    auto red = Crayon{}.bright().red();
+    auto green = Crayon{}.bright().green();
+
+    string emoji = "\n🔋 ";
+    if (isCharging("/sys/class/power_supply/BAT0/status"))
+    {
+        emoji = "\n🔌 ";
+    }
+
+    int width = 50;
+    int pos = width * (float)battery / 100;
+
+    cout << green.text(emoji) << green.text(to_string(battery) + "% ") << green.text("[");;
+    for (int i = 0; i < width; i++) {
+        if (i < pos) 
+        {
+            cout << green.text("=");
+        }
+        else if (i == pos) 
+        {
+            cout << green.text(">");
+        }
+        else 
+        {
+            cout << red.text("-");
+        }
+    }
+    cout << green.text("]") << endl;
+
+    return;
+}
+
+/**
+ * @returns prints battery percentage bar
+ * @param path
+ */
+void print_battery(string path)
+{
+    fstream fptr;
+    fptr.open(path, ios::in);
+    string percent;
+    getline(fptr, percent);
+    print_bar(stoi(percent));
+
+    return;
+}
+
+/**
  * @param art
  * @param color_name
  */

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -57,6 +57,8 @@ vector<string> getGPU();
 
 string getPackages();
 
+void print_battery(string path);
+
 void print(string color, string distro_name);
 
 // util.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,5 +111,8 @@ void DisplayInfo()
     }
 
     cout << title.text("Packages : ") << getPackages() << endl;
+
+    print_battery("/sys/class/power_supply/BAT0/capacity");
+
     cout << endl;
 }


### PR DESCRIPTION
## Closes 
Closes #114 

## Changes
- Add `print_battery` function to print battery percentage bar


## Output
- During discharging
```
🔋 58% [=============================>--------------------]
```
- During charging
```
🔌 57% [============================>---------------------]
```