### PR TITLE
print_process() refers to LIB_DIR

### DIFF
--- a/ascii/Makefile.in
+++ b/ascii/Makefile.in
@@ -1,14 +1,14 @@
 INSTALL = /usr/bin/install -c
-DATADIR = /usr/share/procfetch
+LIB_DIR = @LIB_DIR@
 
 all: 
 install:
-	@echo "Installing $(DATADIR)..."
-	mkdir -p $(DATADIR)/ascii
+	@echo "Installing $(LIB_DIR)..."
+	mkdir -p $(LIB_DIR)/ascii
 	for i in *.ascii; do             \
-		$(INSTALL) "$$i" $(DATADIR)/ascii ;\
+		$(INSTALL) "$$i" $(LIB_DIR)/ascii ;\
 	done
 uninstall:
-	rm -rf $(DATADIR)
+	rm -rf $(LIB_DIR)
 
 .PHONY: all run check gcov clean docs install uninstall dist gif

--- a/configure
+++ b/configure
@@ -4,7 +4,7 @@ set -o nounset
 
 VERSION=$(cat VERSION)
 CONFIG_BREW=OFF
-INSTALL_LIB_DIR="/usr/share/procfetch/ascii"
+LIB_DIR="/usr/share/procfetch"
 
 #
 # parse options
@@ -26,16 +26,12 @@ fi
 #
 
 if [[ $CONFIG_BREW == "ON" ]]; then
-    INSTALL_LIB_DIR="${HOMEBREW_PREFIX:-}/procfetch/ascii"
+    LIB_DIR="${HOMEBREW_PREFIX:-}/procfetch"
 fi
 
-echo "creating Doxyfile"
-sed "s/@PROJECT_NUMBER@/${VERSION}/g" Doxyfile.in > Doxyfile
-
-echo "creating Makefile"
-sed "s/@VERSION@/${VERSION}/g" Makefile.in > Makefile
-
-echo "creating src/config.h"
-sed -e "s/@VERSION@/\"${VERSION}\"/g" \
-    -e "s:@INSTALL_LIB_DIR@:\"${INSTALL_LIB_DIR}\":g" src/config.h.in > src/config.h
-
+for f in Makefile ascii/Makefile src/config.h Doxyfile
+do
+    echo "creating $f"
+    sed -e "s/@VERSION@/${VERSION}/g" \
+        -e "s:@LIB_DIR@:${LIB_DIR}:g" $f.in > $f
+done

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ endif
 
 INSTALL = /usr/bin/install -c
 FORMATTER = clang-format -i
-BINDIR = /bin
+BIN_DIR = /bin
 
 all: $(TARGET)
 run: all
@@ -27,10 +27,10 @@ gcov:
 clean:
 	- rm -f $(TARGET) $(OBJS) *.gcov *.gcda *.gcno
 install: all
-	@echo "Installing $(BINDIR)/$(TARGET) ..."
-	$(INSTALL) $(TARGET) $(BINDIR)/$(TARGET)
+	@echo "Installing $(BIN_DIR)/$(TARGET) ..."
+	$(INSTALL) $(TARGET) $(BIN_DIR)/$(TARGET)
 uninstall:
-	- rm $(BINDIR)/$(TARGET)
+	- rm $(BIN_DIR)/$(TARGET)
 format:
 	$(FORMATTER) $(SRCS) *.h
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,2 +1,7 @@
-#define VERSION @VERSION@
-#define INSTALL_LIB_DIR @INSTALL_LIB_DIR@
+/**
+ * @file
+ */
+#pragma once
+
+#define VERSION "@VERSION@"
+#define LIB_DIR "@LIB_DIR@"

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -506,7 +506,7 @@ void print_battery(string path)
  */
 void print_process(string art, string color_name)
 {
-    string path = "/usr/share/procfetch/ascii/" + art;
+    string path = LIB_DIR + "/ascii/"s + art;
     fstream fptr;
     fptr.open(path, ios::in);
     string txt;


### PR DESCRIPTION
## Description

```bash
$ ./configure -C brew
```

The environment variable ${HOMEBREW_PREFIX} is the prefix of LIB_DIR.

## Changes

1. The variable `DATA_DIR` has been summarized with `LIB_DIR`.
2. Apply same naming conventions to `BINDIR`.　
3. `configure` script generate `ascii/Makefile`
4. Add `LIB_DIR` to `config.h`
5. `print_process()` refers to `LIB_DIR`

## Related

* #108
