### PR TITLE
Fix #124: Introduce --prefix to the configure script 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /Makefile
 src/config.h
 src/procfetch
+src/Makefile
 ascii/Makefile
 *.o
 dist/

--- a/ascii/Makefile.in
+++ b/ascii/Makefile.in
@@ -1,4 +1,4 @@
-INSTALL = /usr/bin/install -c
+INSTALL = /usr/bin/install -c -D
 LIB_DIR = @LIB_DIR@
 
 all: 

--- a/configure
+++ b/configure
@@ -4,6 +4,7 @@ set -o nounset
 
 VERSION=$(cat VERSION)
 CONFIG_BREW=OFF
+BIN_DIR="/bin"
 LIB_DIR="/usr/share/procfetch"
 
 #
@@ -26,12 +27,14 @@ fi
 #
 
 if [[ $CONFIG_BREW == "ON" ]]; then
+    BIN_DIR="${HOMEBREW_PREFIX:-}/bin"
     LIB_DIR="${HOMEBREW_PREFIX:-}/procfetch"
 fi
 
-for f in Makefile ascii/Makefile src/config.h Doxyfile
+for f in Makefile ascii/Makefile src/Makefile src/config.h Doxyfile
 do
     echo "creating $f"
     sed -e "s/@VERSION@/${VERSION}/g" \
+        -e "s:@BIN_DIR@:${BIN_DIR}:g" \
         -e "s:@LIB_DIR@:${LIB_DIR}:g" $f.in > $f
 done

--- a/configure
+++ b/configure
@@ -35,8 +35,8 @@ if [[ $CONFIG_BREW == "ON" ]]; then
     BIN_DIR="${HOMEBREW_PREFIX:-}/bin"
     LIB_DIR="${HOMEBREW_PREFIX:-}/procfetch"
 else
-    BIN_DIR="${PREFIX:-}/${BIN_DIR}"
-    LIB_DIR="${PREFIX:-/usr}/${LIB_DIR}"
+    BIN_DIR="${PREFIX:-}${BIN_DIR}"
+    LIB_DIR="${PREFIX:-/usr}${LIB_DIR}"
 fi
 
 for f in Makefile ascii/Makefile src/Makefile src/config.h Doxyfile

--- a/configure
+++ b/configure
@@ -5,20 +5,25 @@ set -o nounset
 VERSION=$(cat VERSION)
 CONFIG_BREW=OFF
 BIN_DIR="/bin"
-LIB_DIR="/usr/share/procfetch"
+LIB_DIR="/share/procfetch"
 
 #
 # parse options
 #
 
 if [[ $# -ge 2 && $1 == "-C" && $2 == "brew" ]]; then
-    shift 2
     CONFIG_BREW=ON
+    shift 2
+elif [[ $# -ge 1 && ${1%%=*} == "--prefix" ]]; then
+    PREFIX=${1##*=}
+    shift
 fi
 
 if [[ $# -ne 0 ]]; then
     echo "Error: Invalid options or arguments"
-    echo "Usage: $0 [-C brew]"
+    echo "Usage: $0"
+    echo "       $0 -C brew"    
+    echo "       $0 --prefix=<prefix>"
     exit 1
 fi
 
@@ -29,6 +34,9 @@ fi
 if [[ $CONFIG_BREW == "ON" ]]; then
     BIN_DIR="${HOMEBREW_PREFIX:-}/bin"
     LIB_DIR="${HOMEBREW_PREFIX:-}/procfetch"
+else
+    BIN_DIR="${PREFIX:-}/${BIN_DIR}"
+    LIB_DIR="${PREFIX:-/usr}/${LIB_DIR}"
 fi
 
 for f in Makefile ascii/Makefile src/Makefile src/config.h Doxyfile

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -9,7 +9,7 @@ ifeq ($(COVERAGE_TEST), 1)
 	LIBS += -lgcov
 endif
 
-INSTALL = /usr/bin/install -c
+INSTALL = /usr/bin/install -c -D
 FORMATTER = clang-format -i
 BIN_DIR = @BIN_DIR@
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -11,7 +11,7 @@ endif
 
 INSTALL = /usr/bin/install -c
 FORMATTER = clang-format -i
-BIN_DIR = /bin
+BIN_DIR = @BIN_DIR@
 
 all: $(TARGET)
 run: all


### PR DESCRIPTION
## Description

* Introduce `--prefix` to the `configure` script

On the Homebrew formula, call the `configure` with `--prefix`.

## Related Issue

* #124 
