### PR TITLE
Dynamically look for battery info under `/sys/class/power_supply` directory 

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -523,9 +523,10 @@ void printBattery(string path)
 
     for (auto &dir : contents)
     {
-        dir_path = dir.toString();
-        if (dir.isDirectory() && dir_path.substr(0, 2) == "BA")
+        if (dir.isDirectory() &&
+            dir.getFilename().toString().substr(0, 2) == "BA")
         {
+            dir_path = dir.toString();
             break;
         }
     }

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -251,14 +251,6 @@ bool resCheck()
 }
 
 /**
- * @returns checks for Battery folder
- */
-bool batteryCheck(string path)
-{
-    return Path::of(path).isDirectory();
-}
-
-/**
  * @returns gets current Screen Resolution
  * @param path
  */

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -251,6 +251,14 @@ bool resCheck()
 }
 
 /**
+ * @returns checks for Battery folder
+ */
+bool batteryCheck(string path)
+{
+    return Path::of(path).isDirectory();
+}
+
+/**
  * @returns gets current Screen Resolution
  * @param path
  */
@@ -480,13 +488,14 @@ bool isCharging(string path)
 /**
  * @brief Utility to print battery perecentage bar
  */
-void print_bar(int battery)
+void print_bar(string path, int battery)
 {
     auto red = Crayon{}.bright().red();
     auto green = Crayon{}.bright().green();
 
     string emoji = "\n🔋 ";
-    if (isCharging("/sys/class/power_supply/BAT0/status"))
+    string status_path = path + "/status";
+    if (isCharging(status_path))
     {
         emoji = "\n🔌 ";
     }
@@ -521,25 +530,25 @@ void print_bar(int battery)
  */
 void print_battery(string path)
 {
-    cout << "Inside print_battery!\n";
     string dir_path = path;
+    string capacity_path = path;
 
     for (const auto& entry : filesystem::directory_iterator(dir_path)) {
-        if (filesystem::is_directory(entry)) {
+        if (batteryCheck(dir_path)) {
             string filename = entry.path().filename().string();
             if (filename.substr(0, 2) == "BA") {
-                cout << "Found folder starting with 'BA': " << filename << endl;
-                dir_path = dir_path + filename + "/capacity";
-                cout << "dir_path: " << dir_path << endl;
+                dir_path = dir_path + filename;
+                break;
             }
         }
     }
 
+    capacity_path = dir_path + "/capacity";
     fstream fptr;
-    fptr.open(dir_path, ios::in);
+    fptr.open(capacity_path, ios::in);
     string percent;
     getline(fptr, percent);
-    print_bar(stoi(percent));
+    print_bar(dir_path, stoi(percent));
 
     return;
 }

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -488,7 +488,7 @@ bool isCharging(string path)
 /**
  * @brief Utility to print battery perecentage bar
  */
-void print_bar(string path, int battery)
+void printBar(string path, int battery)
 {
     auto red = Crayon{}.bright().red();
     auto green = Crayon{}.bright().green();
@@ -528,7 +528,7 @@ void print_bar(string path, int battery)
  * @returns prints battery percentage bar
  * @param path
  */
-void print_battery(string path)
+void printBattery(string path)
 {
     string dir_path = path;
     string capacity_path = path;
@@ -548,7 +548,7 @@ void print_battery(string path)
     fptr.open(capacity_path, ios::in);
     string percent;
     getline(fptr, percent);
-    print_bar(dir_path, stoi(percent));
+    printBar(dir_path, stoi(percent));
 
     return;
 }
@@ -557,7 +557,7 @@ void print_battery(string path)
  * @param art
  * @param color_name
  */
-void print_process(string art, string color_name)
+void printProcess(string art, string color_name)
 {
     string path = LIB_DIR + "/ascii/"s + art;
     fstream fptr;
@@ -635,12 +635,12 @@ void print(string color_name, string distro_name)
     {
         if (os.find(key) != string::npos)
         {
-            print_process(value, color_name);
+            printProcess(value, color_name);
             return;
         }
     }
 
-    print_process("linux.ascii", color_name);
+    printProcess("linux.ascii", color_name);
 
     return;
 }

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -521,8 +521,22 @@ void print_bar(int battery)
  */
 void print_battery(string path)
 {
+    cout << "Inside print_battery!\n";
+    string dir_path = path;
+
+    for (const auto& entry : filesystem::directory_iterator(dir_path)) {
+        if (filesystem::is_directory(entry)) {
+            string filename = entry.path().filename().string();
+            if (filename.substr(0, 2) == "BA") {
+                cout << "Found folder starting with 'BA': " << filename << endl;
+                dir_path = dir_path + filename + "/capacity";
+                cout << "dir_path: " << dir_path << endl;
+            }
+        }
+    }
+
     fstream fptr;
-    fptr.open(path, ios::in);
+    fptr.open(dir_path, ios::in);
     string percent;
     getline(fptr, percent);
     print_bar(stoi(percent));

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -533,19 +533,18 @@ void printBattery(string path)
     string dir_path = path;
     string capacity_path = path;
 
-    for (const auto& entry : filesystem::directory_iterator(dir_path)) 
+    vector<string> contents = Path::of(path).getDirectoryContents();
+    for (const auto& it : contents)
     {
         if (batteryCheck(dir_path)) 
         {
-            string filename = entry.path().filename().string();
-            if (filename.substr(0, 2) == "BA") 
+            if (it.substr(0, 2) == "BA")
             {
-                dir_path = dir_path + filename;
+                dir_path = dir_path + "/" + it;
                 break;
             }
         }
     }
-
     capacity_path = dir_path + "/capacity";
     fstream fptr;
     fptr.open(capacity_path, ios::in);

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -492,9 +492,9 @@ void printBar(string path, int battery)
 {
     auto red = Crayon{}.bright().red();
     auto green = Crayon{}.bright().green();
-
-    string emoji = "\n🔋 ";
     string status_path = path + "/status";
+    string emoji = "\n🔋 ";
+
     if (isCharging(status_path))
     {
         emoji = "\n🔌 ";
@@ -533,10 +533,13 @@ void printBattery(string path)
     string dir_path = path;
     string capacity_path = path;
 
-    for (const auto& entry : filesystem::directory_iterator(dir_path)) {
-        if (batteryCheck(dir_path)) {
+    for (const auto& entry : filesystem::directory_iterator(dir_path)) 
+    {
+        if (batteryCheck(dir_path)) 
+        {
             string filename = entry.path().filename().string();
-            if (filename.substr(0, 2) == "BA") {
+            if (filename.substr(0, 2) == "BA") 
+            {
                 dir_path = dir_path + filename;
                 break;
             }

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -533,14 +533,16 @@ void printBattery(string path)
     string dir_path = path;
     string capacity_path = path;
 
-    vector<string> contents = Path::of(path).getDirectoryContents();
+    vector<filesystem::path> contents = Path::of(path).getDirectoryContents();
+
     for (const auto& it : contents)
     {
         if (batteryCheck(dir_path)) 
         {
-            if (it.substr(0, 2) == "BA")
+            string last_folder_name = it.filename().string();
+            if (last_folder_name.substr(0, 2) == "BA")
             {
-                dir_path = dir_path + "/" + it;
+                dir_path = dir_path + "/" + last_folder_name;
                 break;
             }
         }

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -62,7 +62,7 @@ vector<string> getGPU();
 
 string getPackages();
 
-void print_battery(string path);
+void printBattery(string path);
 
 void print(string color, string distro_name);
 

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -295,6 +295,19 @@ class Path
     {
         return path.string();
     }
+
+    /**
+     * @returns a vector containing elements at the given path
+     */
+    vector<string> getDirectoryContents()
+    {
+        vector<std::string> contents;
+        for (const auto& entry : filesystem::directory_iterator(path))
+        {
+            contents.push_back(entry.path().filename().string());
+        }
+        return contents;
+    }
 };
 
 /**

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -297,14 +297,14 @@ class Path
     }
 
     /**
-     * @returns a vector containing elements at the given path
+     * @returns a vector containing absolute paths to contents at the given path
      */
-    vector<string> getDirectoryContents()
+    vector<filesystem::path> getDirectoryContents()
     {
-        vector<std::string> contents;
+        vector<filesystem::path> contents;
         for (const auto& entry : filesystem::directory_iterator(path))
         {
-            contents.push_back(entry.path().filename().string());
+            contents.push_back(entry.path());
         }
         return contents;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,7 +124,6 @@ void DisplayInfo(bool show_battery)
 
     if (show_battery)
     {
-        cout << "Inside if(show_battery)\n";
         print_battery("/sys/class/power_supply/");
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,7 +124,7 @@ void DisplayInfo(bool show_battery)
 
     if (show_battery)
     {
-        print_battery("/sys/class/power_supply/");
+        printBattery("/sys/class/power_supply/");
     }
 
     cout << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,7 +124,8 @@ void DisplayInfo(bool show_battery)
 
     if (show_battery)
     {
-        print_battery("/sys/class/power_supply/BAT0/capacity");
+        cout << "Inside if(show_battery)\n";
+        print_battery("/sys/class/power_supply/");
     }
 
     cout << endl;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -108,9 +108,11 @@ static void test_Path()
     // directory is not empty
     p = Path::of("/bin"s);
     vector<Path> directoryContents = p.getDirectoryContents();
-    expect(true, !Path::of("/bin"s).getDirectoryContents().empty(), "Directory is not empty");
+    expect(true, !Path::of("/bin"s).getDirectoryContents().empty(),
+           "Directory is not empty");
     expect(true, Path::of("/bin/ls"s).getDirectoryContents().empty(), "file");
-    expect(true, Path::of("/non_existent_dir"s).getDirectoryContents().empty(), "file");
+    expect(true, Path::of("/non_existent_dir"s).getDirectoryContents().empty(),
+           "file");
 
     // getFilename()
     expect("bar.txt"s, Path::of("/foo/bar.txt").getFilename().toString(),

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -108,7 +108,9 @@ static void test_Path()
     // directory is not empty
     p = Path::of("/bin"s);
     vector<Path> directoryContents = p.getDirectoryContents();
-    expect(true, !directoryContents.empty(), "Directory is not empty");
+    expect(true, !Path::of("/bin"s).getDirectoryContents().empty(), "Directory is not empty");
+    expect(true, Path::of("/bin/ls"s).getDirectoryContents().empty(), "file");
+    expect(true, Path::of("/non_existent_dir"s).getDirectoryContents().empty(), "file");
 
     // getFilename()
     expect("bar.txt"s, Path::of("/foo/bar.txt").getFilename().toString(),

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -88,6 +88,11 @@ static void test_Path()
     expect(false, p.isRegularFile(), "test -f "s + p.toString());
     expect(false, p.isExecutable(), "test -x "s + p.toString());
     expect(false, p.isDirectory(), "test -d "s + p.toString());
+
+    // directory is not empty
+    p = Path::of("/bin"s);
+    vector<filesystem::path> directoryContents = p.getDirectoryContents();
+    expect(true, !directoryContents.empty(), "Directory is not empty");
 }
 
 static void test_Crayon()


### PR DESCRIPTION
## The issue #127 is hereby fixed as can be seen in the attached screenshot.

![image](https://github.com/TanmayPatil105/procfetch/assets/98017423/bc8e92cd-3217-4762-9ef9-68d64ac05c65)

It is also made dynamic for the folder in `/sys/class/power_supply`. The code basically checks for any folder inside this one that starts with 'BA'. The required files of `status` and `capacity` are generally located in BAT0 or BAT1 folder here. The other case maybe of BAPM.

Thus the battery folder will always begin with 'BA' substring. The other folder will be for the adapter which doesn't start with 'BA' at all!

Hope this helps.

Revert back if any changes are required.

Thank you :)