### PR TITLE
Always check unknown argument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,13 @@ int main(int argc, char *argv[])
         }
     }
 
+    if (optind != argc)
+    {
+        cout << "Error: "s << argv[0] << ": unknown argument: "s << argv[optind]
+             << endl;
+        return 1;
+    }
+
     switch (mode)
     {
     case Mode::NORMAL:
@@ -60,13 +67,6 @@ int main(int argc, char *argv[])
     }
 
     // Mode::NORMAL
-    if (optind != argc)
-    {
-        cout << "Error: "s << argv[0] << ": unknown argument: "s << argv[optind]
-             << endl;
-        return 1;
-    }
-
     print(color_name, distro_name);
     DisplayInfo(show_battery);
 


### PR DESCRIPTION
If the `-t` and `-v` options were specified, no checks were made for unknown arguments.

For example, when an unknown argument `X` is specified after the option `-t`, ignore it.
```
$ procfetch -v X
0.2.1
```

This PR changes this to report unknown arguments as errors.
```
$ procfetch -v X
Error: procfetch: unknown argument: X
```

One advantage is that this simplifies the code.