### PR TITLE
Support macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,14 @@
 
 for building
 
+* GNU getopt - 2.37.2 or later
 * GNU Make - 4.3 or later
 * GCC - 11.3.0 or later
+
+for macOS, You can install gnu-getopt by runnning the following command.
+```
+$ brew install gnu-getopt
+```
 
 for generating API documents
 

--- a/configure
+++ b/configure
@@ -13,6 +13,8 @@ LIB_DIR=/share/procfetch
 
 if [[ -d "/usr/local/opt/gnu-getopt/bin" ]]; then
     PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+elif [[ -d "/opt/homebrew/opt/gnu-getopt/bin" ]]; then
+    PATH="/opt/homebrew/opt/gnu-getopt/bin:$PATH"
 fi
 
 function show_usage {


### PR DESCRIPTION
* Instructions for installing `gnu-getopt` have been added to `README.md`.
* The `configure` script has been modified to work on macOS.
