### PR TITLE
Fix missing adduser on the docker image ubuntu:latest.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ RUN apt-get update &&\
 RUN adduser --disabled-password --gecos '' user
 RUN echo 'user ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/user
 
-USER user
 WORKDIR /home/user
+USER user

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update &&\
     apt-get install -y --no-install-recommends \
-            sudo \
+            adduser sudo \
             make g++ gdb \
             clang-format \
             doxygen graphviz &&\

--- a/docker/clang-ubuntu
+++ b/docker/clang-ubuntu
@@ -4,12 +4,12 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update &&\
     apt-get install -y --no-install-recommends \
-            clang lldb clang-format make sudo &&\    
+            clang lldb clang-format make adduser sudo &&\    
     apt-get -y clean &&\
     rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-password --gecos '' user
 RUN echo 'user ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/user
 
-USER user
 WORKDIR /home/user
+USER user

--- a/docker/gcc-alipine
+++ b/docker/gcc-alipine
@@ -6,5 +6,5 @@ RUN apk update && \
 RUN adduser --disabled-password --gecos '' user
 RUN echo 'user ALL=(root) NOPASSWD:ALL' > /etc/sudoers.d/user
 
-USER user
 WORKDIR /home/user
+USER user


### PR DESCRIPTION
The docker image `ubuntu:latest` has been changed to 24.04 LTS.
The new image does not install the `adduser` command by default, which causes errors when building the docker image `procfetch`.
This pull request contains changes to the `Dockerfile`.

## Related Issue(s)

This pull request fixes the issue #146.