### PR TITLE
Make git ignore debian/control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ src/config.h
 src/procfetch
 src/Makefile
 ascii/Makefile
+debian/control
 *.o
 dist/
 docs/


### PR DESCRIPTION
Make sure that git ignores the generated `debian/control` file.