### PR TITLE
Output of `dpkg -l` includes header information

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -380,8 +380,8 @@ string getPackages()
     {
         Command::exec_async("dpkg -l"s, [&](auto c) {
             std::lock_guard<std::mutex> lock(mtx);
-            if (c->getOutputLines() > 0)
-                pkgs.push_back(rec{"dpkg"s, c->getOutputLines()});
+            if (c->getOutputLines() > 5)
+                pkgs.push_back(rec{"dpkg"s, c->getOutputLines() - 5});
         });
     }
     if (Path::of("/bin/snap"s).isExecutable())


### PR DESCRIPTION
First five rows of `dpkg -l` includes header information

```
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                          Version                                  Architecture Description
+++-=============================================-========================================-============-================================================================================
ii  accountsservice                               23.13.9-2ubuntu6                         amd64        query and manipulate user account information
ii  acl                                           2.3.2-1build1                            amd64        access control list - utilities
...
```