### PR TITLE
Reduce the width of  battery percentage bar

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -498,7 +498,7 @@ void print_bar(int battery)
         emoji = "\n🔌 ";
     }
 
-    int width = 50;
+    int width = 40;
     int pos = width * battery / 100.0;
 
     cout << emoji << green.text(to_string(battery) + "% ") << green.text("[");


### PR DESCRIPTION
I think current battery percentage width is quite large and causes the text to wrap onto a newline for smaller terminal sizes. Reducing it 40 characters would make it look better, in my opinion.

![image](https://github.com/TanmayPatil105/procfetch/assets/92677342/93d85d9f-8f67-423e-921f-916f7c796ab8)
