### PR TITLE
Reduce memory footprint of procfetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /Makefile
 src/config.h
 src/procfetch
+src/test
 src/Makefile
 ascii/Makefile
 debian/control

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -23,7 +23,7 @@ build-test:	$(TESTS)
 check: build-test
 	./$(TEST_TARGET)
 gcov:
-	gcov $(SRCS)
+	gcov $(TESTS)
 clean:
 	- rm -f $(TARGET) $(OBJS) $(TEST_TARGET) $(TEST_OBJS) *.gcov *.gcda *.gcno
 install: all

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,6 +1,9 @@
 TARGET = procfetch
-SRCS = fetch.cpp main.cpp util.cpp
+TEST_TARGET = test
+SRCS = fetch.cpp main.cpp
+TESTS = test.cpp fetch.cpp
 OBJS = $(SRCS:.cpp=.o)
+TEST_OBJS = $(TESTS:.cpp=.o)
 
 CXX = @CXX@
 CXXFLAGS = -std=c++17 -Wall -Wextra --pedantic-errors @CXXFLAGS@
@@ -14,28 +17,27 @@ BIN_DIR = @BIN_DIR@
 all: $(TARGET)
 run: all
 	./$(TARGET)
-check: all
-	@if test -f not_existence; then \
-		echo "Error: It is assumed that file 'not_existence' DOES NOT exist." ;\
-		false ;\
-	fi
-	./$(TARGET) -t
+build-test:	$(TESTS)
+	$(CXX) $(CXXFLAGS) -c $(TESTS)
+	$(CXX) $(CXXFLAGS) -o $(TEST_TARGET) $(TEST_OBJS) $(LD_FLAGS) -no-pie
+check: build-test
+	./$(TEST_TARGET)
 gcov:
 	gcov $(SRCS)
 clean:
-	- rm -f $(TARGET) $(OBJS) *.gcov *.gcda *.gcno
+	- rm -f $(TARGET) $(OBJS) $(TEST_TARGET) $(TEST_OBJS) *.gcov *.gcda *.gcno
 install: all
 	@echo "Installing $(BIN_DIR)/$(TARGET) ..."
 	$(INSTALL) $(TARGET) "$(BIN_DIR)/$(TARGET)"
 uninstall:
 	- rm "$(BIN_DIR)/$(TARGET)"
 format:
-	$(FORMATTER) $(SRCS) *.h
+	$(FORMATTER) $(SRCS) $(TESTS) *.h
 
 $(TARGET): $(OBJS)
 	$(CXX) -o $@ $(OBJS) $(LIBS) $(LDFLAGS)
 main.o:  fetch.h color.h config.h
 fetch.o: fetch.h color.h
-util.o:  fetch.h color.h
+test.o: fetch.h color.h
 
 .PHONY: all run check gcov clean docs install uninstall dist format gif

--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -20,8 +20,7 @@ string getuser()
     auto *p = getpwuid(getuid());
     if (p == NULL)
     {
-        throw runtime_error(
-            "Could not get struct passwd: "s + strerror(errno));
+        throw runtime_error("Could not get struct passwd: "s + strerror(errno));
     }
 
     return p->pw_name;
@@ -644,14 +643,4 @@ void print(string color_name, string distro_name)
     printProcess("linux.ascii", color_name);
 
     return;
-}
-
-void test_getuser()
-{
-    expect(string(getenv("USER")), getuser(), "getuser"s);
-}
-
-void test_fetch()
-{
-    test_getuser();
 }

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -67,40 +67,7 @@ void printBattery(string path);
 
 void print(string color, string distro_name);
 
-void test_fetch();
-
-// util.cpp
-
 string getColor(string);
-
-void test_util();
-
-/**
- * Tests that want and got are equal.
- * Fails with the supplied failure message, file and line then halt.
- * @param want
- * @param got
- * @param msg
- * @param file
- * @param line
- */
-template <typename T>
-void expect1(const T &want, const T &got, const string &msg, const char *file,
-             int line)
-{
-    if (want == got)
-        return;
-
-    if (msg.length() != 0)
-        cout << file << ":"s << line << ": Error: "s << msg << " want ("s
-             << want << "), but got ("s << got << ")"s << endl;
-    else
-        cout << file << ":"s << line << ": Error: want ("s << want
-             << "), but got ("s << got << ")"s << endl;
-
-    exit(1);
-}
-#define expect(want, got, msg) expect1(want, got, msg, __FILE__, __LINE__)
 
 /**
  * A Path represents a path.
@@ -430,7 +397,6 @@ class Context
 enum class Mode
 {
     NORMAL,
-    EXEC_TEST,
     SHOW_VERSION,
 };
 
@@ -446,14 +412,11 @@ class Options
     Options(int argc, char *argv[])
     {
         int opt;
-        while ((opt = getopt(argc, argv, "ta:d:vb")) != -1)
+        while ((opt = getopt(argc, argv, "a:d:vb")) != -1)
         {
 
             switch (opt)
             {
-            case 't':
-                mode = Mode::EXEC_TEST;
-                break;
             case 'a':
                 color_name = string(optarg);
                 break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,10 +26,6 @@ int main(int argc, char *argv[])
     case Mode::NORMAL:
         // no-op
         break;
-    case Mode::EXEC_TEST:
-        test_suite();
-        cout << Crayon{}.green().text("All unit tests passed."s) << endl;
-        return 0;
     case Mode::SHOW_VERSION:
         cout << VERSION << endl;
         return 0;
@@ -100,10 +96,4 @@ void DisplayInfo(bool show_battery)
     }
 
     cout << endl;
-}
-
-void test_suite()
-{
-    test_fetch();
-    test_util();
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -1,7 +1,59 @@
-/**
+/*
  * @file
  */
+#include "color.h"
 #include "fetch.h"
+
+/**
+ * Tests that want and got are equal.
+ * Fails with the supplied failure message, file and line then halt.
+ * @param want
+ * @param got
+ * @param msg
+ * @param file
+ * @param line
+ */
+template <typename T>
+void expect1(const T &want, const T &got, const string &msg, const char *file,
+             int line)
+{
+    if (want == got)
+        return;
+
+    if (msg.length() != 0)
+        cout << file << ":"s << line << ": Error: "s << msg << " want ("s
+             << want << "), but got ("s << got << ")"s << endl;
+    else
+        cout << file << ":"s << line << ": Error: want ("s << want
+             << "), but got ("s << got << ")"s << endl;
+
+    exit(1);
+}
+#define expect(want, got, msg) expect1(want, got, msg, __FILE__, __LINE__)
+
+/*
+ * .---------------------------------------------.
+ * |                FETCH TESTS                  |
+ * '---------------------------------------------'
+ */
+static void test_getuser()
+{
+    expect(string(getenv("USER")), getuser(), "getuser"s);
+}
+
+/*
+ * Test fetch functions
+ */
+static void test_fetch()
+{
+    test_getuser();
+}
+
+/*
+ * .---------------------------------------------.
+ * |                UTILS TESTS                  |
+ * '---------------------------------------------'
+ */
 
 static void test_Command()
 {
@@ -176,20 +228,6 @@ static void test_Options_full()
     testhelper_Options("full", argc, argv, expect, 6); // remains last "arg"
 }
 
-static void test_Options_test()
-{
-    int argc = 2;
-    const char *argv[] = {"procfetch", "-t", NULL};
-
-    Options expect;
-    expect.mode = Mode::EXEC_TEST;
-    expect.color_name = "def"s;
-    expect.distro_name = "def"s;
-    expect.show_battery = false;
-
-    testhelper_Options("test", argc, argv, expect, 2);
-}
-
 static void test_Options_version()
 {
     int argc = 2;
@@ -208,7 +246,6 @@ static void test_Options()
 {
     test_Options_default();
     test_Options_full();
-    test_Options_test();
     test_Options_version();
 }
 
@@ -217,7 +254,7 @@ static void test_Options()
  * * class Path
  * * class Command
  */
-void test_util()
+static void test_util()
 {
     test_Path();
     test_Command();
@@ -227,4 +264,12 @@ void test_util()
     test_Command_async_exception();
     test_Crayon();
     test_Options();
+}
+
+int main()
+{
+    test_fetch();
+    test_util();
+
+    cout << Crayon{}.green().text("All unit tests passed."s) << endl;
 }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -272,4 +272,6 @@ int main()
     test_util();
 
     cout << Crayon{}.green().text("All unit tests passed."s) << endl;
+
+    return 0;
 }


### PR DESCRIPTION
We should try to reduce the size of executable to as less as possible by removing redundant pieces of code


# Changes

## Move tests to a separate executable
This reduces size of `procfetch` by 76 KB
```console
tanmay@tanmay-lenovo:~/Desktop/projects/procfetch$ du -sh /usr/bin/procfetch 
364K	/usr/bin/procfetch
tanmay@tanmay-lenovo:~/Desktop/projects/procfetch$ du -sh ./src/procfetch 
288K	./src/procfetch
```