### PR TITLE
Fix memory leaks

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -76,7 +76,10 @@ string getOS(string path)
  */
 string getHardwarePlatform()
 {
-    string s = Command::exec("uname -m"s)->getOutput();
+    auto cmd = Command::exec("uname -m"s);
+    string s = cmd->getOutput();
+    delete cmd;
+
     s = s.substr(0, s.find("\n"));
     return " " + s;
 }
@@ -277,7 +280,10 @@ string getRES(string path)
 string getTheme()
 {
     auto args = "gsettings get org.gnome.desktop.interface gtk-theme"s;
-    auto s = Command::exec(args)->getOutput();
+    auto cmd = Command::exec(args);
+    auto s = cmd->getOutput();
+    delete cmd;
+
     return s.substr(1, s.find("\'", 1) - 1);
 }
 
@@ -287,7 +293,10 @@ string getTheme()
 string getIcons()
 {
     auto args = "gsettings get org.gnome.desktop.interface icon-theme"s;
-    auto s = Command::exec(args)->getOutput();
+    auto cmd = Command::exec(args);
+    auto s = cmd->getOutput();
+    delete cmd;
+
     return s.substr(1, s.find("\'", 1) - 1);
 }
 
@@ -342,8 +351,9 @@ int getCPUtemp(string path)
 vector<string> getGPU()
 {
     vector<string> gpu;
-    string igpu =
-        Command::exec("lspci | grep -E  \"VGA|3D|Display\"")->getOutput();
+    auto cmd = Command::exec("lspci | grep -E  \"VGA|3D|Display\"");
+    string igpu = cmd->getOutput();
+    delete cmd;
     int temp = 0, k = 0;
 
     for (size_t i = 0; i < igpu.size(); i++)
@@ -357,6 +367,7 @@ vector<string> getGPU()
             k++;
         }
     }
+
     return gpu;
 }
 

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -222,6 +222,7 @@ class Command
             {
                 auto result = exec(cmd);
                 func(result);
+                delete result;
             }
             catch (const runtime_error &e)
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,10 +57,10 @@ void DisplayInfo(bool show_battery)
 
     cout << title.text("OS") << delim << getOS("/etc/os-release")
          << getHardwarePlatform() << endl;
-    cout << title.text("Host") << delim << getHost("/sys/devices/virtual/dmi/id/")
-         << endl;
-    cout << title.text("Kernel") << delim << getKernel("/proc/sys/kernel/osrelease")
-         << endl;
+    cout << title.text("Host") << delim
+         << getHost("/sys/devices/virtual/dmi/id/") << endl;
+    cout << title.text("Kernel") << delim
+         << getKernel("/proc/sys/kernel/osrelease") << endl;
     cout << title.text("UpTime") << delim << getUpTime("/proc/uptime") << endl;
     cout << title.text("RAM") << delim << getRAM("/proc/meminfo") << endl;
     cout << title.text("shell") << delim << getSHELL("/etc/passwd") << endl;


### PR DESCRIPTION
Fixes #156 

## Valgrind

No more memory leaks
```console
$ valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes src/procfetch 
==99702== Memcheck, a memory error detector
==99702== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==99702== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==99702== Command: src/procfetch
==99702== 

   __  __ __                   __        
  / / / // /_   __  __ ____   / /_ __  __
 / / / // __ \ / / / // __ \ / __// / / /
/ /_/ // /_/ // /_/ // / / // /_ / /_/ / 
\____//_.___/ \__,_//_/ /_/ \__/ \__,_/  
                                         
                                         
tanmay@tanmay-lenovo

OS : Ubuntu 24.04 LTS x86_64
Host : 81DE Lenovo ideapad 330-15IKB
Kernel : 6.8.0-35-generic
UpTime : 10 hours, 26 mins
RAM : 3257MiB / 7848MiB
shell : fish
DE : ubuntu:GNOME
Resolution : 1366x768
Theme : Yaru-red-dark
Icons : Yaru-red
CPU : Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
CPU Temperature : 45 °C
GPU : Intel Corporation UHD Graphics 620
GPU : NVIDIA Corporation GP108M [GeForce MX150]
Packages : 2710 dpkg; 49 flatpak; 14 snap; 

==99702== 
==99702== HEAP SUMMARY:
==99702==     in use at exit: 0 bytes in 0 blocks
==99702==   total heap usage: 443 allocs, 443 frees, 1,476,665 bytes allocated
==99702== 
==99702== All heap blocks were freed -- no leaks are possible
==99702== 
==99702== For lists of detected and suppressed errors, rerun with: -s
==99702== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```