### PR TITLE
Fix Command::exec()

### DIFF
--- a/src/fetch.cpp
+++ b/src/fetch.cpp
@@ -77,8 +77,7 @@ string getOS(string path)
 string getHardwarePlatform()
 {
     auto cmd = Command::exec("uname -m"s);
-    string s = cmd->getOutput();
-    delete cmd;
+    string s = cmd.getOutput();
 
     s = s.substr(0, s.find("\n"));
     return " " + s;
@@ -281,8 +280,7 @@ string getTheme()
 {
     auto args = "gsettings get org.gnome.desktop.interface gtk-theme"s;
     auto cmd = Command::exec(args);
-    auto s = cmd->getOutput();
-    delete cmd;
+    auto s = cmd.getOutput();
 
     return s.substr(1, s.find("\'", 1) - 1);
 }
@@ -294,8 +292,7 @@ string getIcons()
 {
     auto args = "gsettings get org.gnome.desktop.interface icon-theme"s;
     auto cmd = Command::exec(args);
-    auto s = cmd->getOutput();
-    delete cmd;
+    auto s = cmd.getOutput();
 
     return s.substr(1, s.find("\'", 1) - 1);
 }
@@ -352,8 +349,7 @@ vector<string> getGPU()
 {
     vector<string> gpu;
     auto cmd = Command::exec("lspci");
-    istringstream ss(cmd->getOutput());
-    delete cmd;
+    istringstream ss(cmd.getOutput());
     string s;
 
     while (std::getline(ss, s))
@@ -387,40 +383,40 @@ string getPackages()
     {
         Command::exec_async("dpkg -l"s, [&](auto c) {
             std::lock_guard<std::mutex> lock(mtx);
-            if (c->getOutputLines() > 5)
-                pkgs.push_back(rec{"dpkg"s, c->getOutputLines() - 5});
+            if (c.getOutputLines() > 5)
+                pkgs.push_back(rec{"dpkg"s, c.getOutputLines() - 5});
         });
     }
     if (Path::of("/bin/snap"s).isExecutable())
     {
         Command::exec_async("snap list"s, [&](auto c) {
             std::lock_guard<std::mutex> lock(mtx);
-            if (c->getOutputLines() > 1)
-                pkgs.push_back(rec{"snap"s, c->getOutputLines()});
+            if (c.getOutputLines() > 1)
+                pkgs.push_back(rec{"snap"s, c.getOutputLines()});
         });
     }
     if (Path::of("/bin/pacman"s).isExecutable())
     {
         Command::exec_async("pacman -Q"s, [&](auto c) {
             std::lock_guard<std::mutex> lock(mtx);
-            if (c->getOutputLines() > 0)
-                pkgs.push_back(rec{"pacman"s, c->getOutputLines()});
+            if (c.getOutputLines() > 0)
+                pkgs.push_back(rec{"pacman"s, c.getOutputLines()});
         });
     }
     if (Path::of("/bin/flatpak"s).isExecutable())
     {
         Command::exec_async("flatpak list"s, [&](auto c) {
             std::lock_guard<std::mutex> lock(mtx);
-            if (c->getOutputLines() > 1)
-                pkgs.push_back(rec{"flatpak"s, c->getOutputLines()});
+            if (c.getOutputLines() > 1)
+                pkgs.push_back(rec{"flatpak"s, c.getOutputLines()});
         });
     }
     if (Path::of("/var/lib/rpm"s).isExecutable())
     {
         Command::exec_async("rpm -qa"s, [&](auto c) {
             std::lock_guard<std::mutex> lock(mtx);
-            if (c->getOutputLines() > 0)
-                pkgs.push_back(rec{"rpm"s, c->getOutputLines()});
+            if (c.getOutputLines() > 0)
+                pkgs.push_back(rec{"rpm"s, c.getOutputLines()});
         });
     }
     if (Path::of("/bin/emerge"s).isExecutable()) // gentoo
@@ -431,16 +427,16 @@ string getPackages()
     {
         Command::exec_async("flatpak list"s, [&](auto c) {
             std::lock_guard<std::mutex> lock(mtx);
-            if (c->getOutputLines() > 0)
-                pkgs.push_back(rec{"xbps"s, c->getOutputLines()});
+            if (c.getOutputLines() > 0)
+                pkgs.push_back(rec{"xbps"s, c.getOutputLines()});
         });
     }
     if (Path::of("/bin/zypper"s).isExecutable()) // opensuse
     {
         Command::exec_async("zypper se --installed-only"s, [&](auto c) {
             std::lock_guard<std::mutex> lock(mtx);
-            if (c->getOutputLines() > 0)
-                pkgs.push_back(rec{"zypper"s, c->getOutputLines()});
+            if (c.getOutputLines() > 0)
+                pkgs.push_back(rec{"zypper"s, c.getOutputLines()});
         });
     }
 
@@ -449,9 +445,9 @@ string getPackages()
     {
         Command::exec_async(cmd, "list"s, [&](auto c) {
             std::lock_guard<std::mutex> lock(mtx);
-            if (c->getOutputLines() > 0)
+            if (c.getOutputLines() > 0)
                 pkgs.push_back(
-                    rec{cmd.getFilename().toString(), c->getOutputLines()});
+                    rec{cmd.getFilename().toString(), c.getOutputLines()});
         });
     }
 

--- a/src/fetch.h
+++ b/src/fetch.h
@@ -176,7 +176,7 @@ class Path
 class Command
 {
   public:
-    typedef std::function<void(Command *)> func_type;
+    typedef std::function<void(Command)> func_type;
 
   private:
     int exit_code;
@@ -238,7 +238,6 @@ class Command
             {
                 auto result = exec(cmd);
                 func(result);
-                delete result;
             }
             catch (const runtime_error &e)
             {
@@ -266,9 +265,9 @@ class Command
      * @returns Command object for getting the results.
      * @throws runtime_error failed to popen(3)
      */
-    static Command *exec(const string &cmd)
+    static Command exec(const string &cmd)
     {
-        auto result = new Command();
+        auto result = Command{};
         int out_fd[2], err_fd[2];
         pid_t pid;
 
@@ -348,14 +347,14 @@ class Command
         {
             if (c == '\n')
             {
-                result->lines += 1;
+                result.lines += 1;
             }
-            result->output += c;
+            result.output += c;
         }
 
         while ((c = fgetc(err)) != EOF)
         {
-            result->error_output += c;
+            result.error_output += c;
         }
 
         if (fclose(out) == EOF)
@@ -372,7 +371,7 @@ class Command
         waitpid(pid, &status, 0);
         if (WIFEXITED(status))
         {
-            result->exit_code = WEXITSTATUS(status);
+            result.exit_code = WEXITSTATUS(status);
         }
         else if (WIFSIGNALED(status))
         {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -60,22 +60,22 @@ static void test_fetch()
 static void test_Command()
 {
     auto c = Command::exec("../test/seafood.sh"s);
-    expect(0, c->getExitCode(), "Exit code"s);
-    expect("wakame\n"s, c->getOutput(), "getOutput()"s);
-    expect(1, c->getOutputLines(), "getOutputLines()"s);
-    expect("akamoku\n"s, c->getErrorOutput(), "getErrorOutput()"s);
+    expect(0, c.getExitCode(), "Exit code"s);
+    expect("wakame\n"s, c.getOutput(), "getOutput()"s);
+    expect(1, c.getOutputLines(), "getOutputLines()"s);
+    expect("akamoku\n"s, c.getErrorOutput(), "getErrorOutput()"s);
 
     c = Command::exec("ls ../README.md"s);
-    expect("../README.md\n"s, c->getOutput(), "argc = 2"s);
+    expect("../README.md\n"s, c.getOutput(), "argc = 2"s);
 
     c = Command::exec("false"s);
-    expect(1, c->getExitCode(), "Exit code"s);
+    expect(1, c.getExitCode(), "Exit code"s);
 
     c = Command::exec("./not-exist"s);
-    expect(127, c->getExitCode(), "Exit code"s);
+    expect(127, c.getExitCode(), "Exit code"s);
 
     c = Command::exec("../README.md"s); // not executable
-    expect(126, c->getExitCode(), "Exit code"s);
+    expect(126, c.getExitCode(), "Exit code"s);
 }
 
 static void test_Command_exception()
@@ -98,12 +98,12 @@ static void test_Command_async()
     int lines;
     int status[2];
     Command::exec_async("ls Makefile"s, [&](auto c) {
-        out = c->getOutput();
-        lines = c->getOutputLines();
+        out = c.getOutput();
+        lines = c.getOutputLines();
     });
-    Command::exec_async("true"s, [&](auto c) { status[0] = c->getExitCode(); });
+    Command::exec_async("true"s, [&](auto c) { status[0] = c.getExitCode(); });
     Command::exec_async("false"s,
-                        [&](auto c) { status[1] = c->getExitCode(); });
+                        [&](auto c) { status[1] = c.getExitCode(); });
 
     Command::wait();
 
@@ -120,8 +120,8 @@ static void test_Command_async2()
     auto cmd = Path::of("/bin/ls"s);
 
     Command::exec_async(cmd, "Makefile"s, [&](auto c) {
-        out = c->getOutput();
-        lines = c->getOutputLines();
+        out = c.getOutput();
+        lines = c.getOutputLines();
     });
     Command::wait();
 
@@ -134,7 +134,7 @@ static void test_Command_async_exception()
     int status = 0;
 
     Command::exec_async("./not-executable"s,
-                        [&](auto c) { status = c->getExitCode(); });
+                        [&](auto c) { status = c.getExitCode(); });
     Command::wait();
     auto size = Command::getExceptions().size();
 


### PR DESCRIPTION
Issue #156 was resolved in pull request #157.
The solution was to explicitly delete the new Command object in the exec() member function.

It would be better designed to modify the exec() member function so that it does not require explicit deletion. That is what I am implementing in this pull request.